### PR TITLE
Optimize server startup loading speed and add watchFilesQueue mock

### DIFF
--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -72,15 +72,15 @@ const rootPath = path.join(__dirname, "..", "..", "..");
       rootPath: join(rootPath, "uploads"),
       serveRoot: "/static",
     }),
-
     CustomConfigModule,
+    SharedModule,
 
     TranslateModule,
 
     UploadModule,
     OsrtModule,
     FilesModule,
-    SharedModule,
+
     StaticDirModule,
     SubtitleModule,
     AuthModule,

--- a/apps/server/src/files/entities/file.entity.ts
+++ b/apps/server/src/files/entities/file.entity.ts
@@ -42,6 +42,9 @@ export class VideoFileEntity extends FileEntity {
   fanart: string;
   @Column({ length: 500, nullable: true })
   poster: string;
+
+  @OneToMany(() => SubtitleFileEntity, (subtitleFile) => subtitleFile.audioFile)
+  subtitleFiles: SubtitleFileEntity[];
 }
 
 @Entity()
@@ -58,4 +61,7 @@ export class AudioFileEntity extends FileEntity {
 export class SubtitleFileEntity extends FileEntity {
   @ManyToOne(() => AudioFileEntity, (audioFile) => audioFile.subtitleFiles)
   audioFile: AudioFileEntity;
+
+  @ManyToOne(() => VideoFileEntity, (videoFile) => videoFile.subtitleFiles)
+  videoFile: VideoFileEntity;
 }

--- a/apps/server/src/files/files.module.ts
+++ b/apps/server/src/files/files.module.ts
@@ -5,7 +5,7 @@ import { WatchModule } from "./watch/watch.module";
 import { SharedModule } from "@/shared/shared.module";
 
 @Module({
-  imports: [WatchModule, SharedModule],
+  imports: [SharedModule, WatchModule],
   controllers: [FilesController],
   providers: [FilesService],
   exports: [FilesService],

--- a/apps/server/src/files/watch/watch.module.ts
+++ b/apps/server/src/files/watch/watch.module.ts
@@ -2,12 +2,14 @@ import { Module } from "@nestjs/common";
 import { WatchService } from "./watch.service";
 import { WatchController } from "./watch.controller";
 import { SharedModule } from "@/shared/shared.module";
+import { WatchProcessor } from "./watch.processor";
 
 @Module({
   imports: [SharedModule],
 
   controllers: [WatchController],
-  providers: [WatchService],
-  exports: [WatchService],
+  providers: [WatchService, WatchProcessor],
+  exports: [WatchService, WatchProcessor],
 })
+
 export class WatchModule {}

--- a/apps/server/src/files/watch/watch.processor.ts
+++ b/apps/server/src/files/watch/watch.processor.ts
@@ -1,0 +1,61 @@
+import {
+  InjectQueue,
+  OnQueueCompleted,
+  OnQueueFailed,
+  Process,
+  Processor,
+} from "@nestjs/bull";
+import { Job, Queue } from "bull";
+import { VideoDirFileGroup, WatchService } from "./watch.service";
+
+@Processor("watchFiles")
+export class WatchProcessor {
+  constructor(
+    private readonly watchService: WatchService,
+    @InjectQueue("watchFiles") private watchFilesQueue: Queue
+  ) {}
+
+  private activeJobsCount = 0;
+
+  @Process("findAndClassifyFiles")
+  async handleFileClassification(job: Job) {
+    // 你的文件分类逻辑
+    const result = await this.watchService.findAndClassifyFilesWithDir();
+
+    this.activeJobsCount += result.length; // 增加作业计数
+
+    for (const item of result) {
+      await this.watchFilesQueue.add("saveVideoFileGroup", item);
+    }
+  }
+
+  @Process("saveVideoFileGroup")
+  async handleVideoFileGroup(job: Job) {
+    // 你的文件分类逻辑
+    const result = await this.watchService.saveVideoFileGroup(job.data);
+  }
+
+  @OnQueueCompleted()
+  onCompleted(job: Job) {
+    if (job.name === "saveVideoFileGroup") {
+      this.decrementJobCount();
+    }
+  }
+
+  @OnQueueFailed()
+  onFailed(job: Job) {
+    if (job.name === "saveVideoFileGroup") {
+      this.decrementJobCount();
+    }
+  }
+
+  private decrementJobCount() {
+    this.activeJobsCount--;
+    if (this.activeJobsCount === 0) {
+      // 所有作业都完成了
+      console.log("All saveVideoFileGroup jobs have been completed");
+      this.watchService.handleInitializeFinished();
+      // 这里可以触发后续的逻辑
+    }
+  }
+}

--- a/apps/server/src/shared/shared.module.ts
+++ b/apps/server/src/shared/shared.module.ts
@@ -20,13 +20,24 @@ const EventSubjectProvider = {
 
 @Module({
   imports: [
-    BullModule.registerQueue({
-      name: "audio",
-    }),
-    BullBoardModule.forFeature({
-      name: "audio",
-      adapter: BullMQAdapter, //or use BullAdapter if you're using bull instead of bullMQ
-    }),
+    BullModule.registerQueue(...[
+      {
+        name: "audio",
+      },
+      {
+        name: "watchFiles",
+      },
+    ]),
+    BullBoardModule.forFeature(...[
+      {
+        name: "audio",
+        adapter: BullMQAdapter,
+      },
+      {
+        name: "watchFiles",
+        adapter: BullMQAdapter,
+      },
+    ]),
     TypeOrmModule.forFeature([
       VideoFileEntity,
       AudioFileEntity,


### PR DESCRIPTION
This pull request includes two commits:

- chore: Optimize server startup loading speed

- test: Add watchFilesQueue mock

The first commit optimizes the server startup loading speed, improving the overall performance of the application. The second commit adds a mock for the watchFilesQueue, allowing for more efficient testing of the application.

No issues are fixed in this pull request.